### PR TITLE
ssh_option user added for consistency

### DIFF
--- a/lib/capistrano/consul.rb
+++ b/lib/capistrano/consul.rb
@@ -11,7 +11,7 @@ module Capistrano
       return false unless @url
       @ssh_gateway = fetch(:consul_ssh_gateway)
       if @ssh_gateway
-        @gateway = Net::SSH::Gateway.new(@ssh_gateway[:host], @ssh_gateway[:username], @ssh_gateway[:options] || {})
+        @gateway = Net::SSH::Gateway.new(@ssh_gateway[:host], @ssh_gateway[:username] || @ssh_gateway[:user], @ssh_gateway[:options] || {})
         @gateway.open('127.0.0.1', @ssh_gateway[:port], @ssh_gateway[:port])
       end
 


### PR DESCRIPTION
You use 'username' here in the code
In [capistrano](http://capistranorb.com/documentation/advanced-features/properties/) (i guess in sshkit as well) the option for setting a username is 'user' instead of 'username' 
Also the README of this projects says you should be using 'user' 



